### PR TITLE
Allow wrapping ISmartItemModel and IFlexibleBakedModel

### DIFF
--- a/src/main/java/itemtransformhelper/ClientTickHandler.java
+++ b/src/main/java/itemtransformhelper/ClientTickHandler.java
@@ -14,6 +14,7 @@ import net.minecraftforge.fml.common.gameevent.TickEvent;
  * Every tick, check all the items in the hotbar to see if any are the mbe14 ItemCamera.  If so, apply the transform
  *   override to the held item.
  */
+@SuppressWarnings("deprecation")
 public class ClientTickHandler
 {
   @SubscribeEvent
@@ -27,7 +28,7 @@ public class ClientTickHandler
 
     boolean foundCamera = false;
     InventoryPlayer inventoryPlayer = player.inventory;
-    for (int i = 0; i < inventoryPlayer.getHotbarSize(); ++i) {
+    for (int i = 0; i < InventoryPlayer.getHotbarSize(); ++i) {
       ItemStack slotItemStack = inventoryPlayer.mainInventory[i];
       if (slotItemStack != null && slotItemStack.getItem() == StartupCommon.itemCamera) {
         foundCamera = true;

--- a/src/main/java/itemtransformhelper/HUDtextRenderer.java
+++ b/src/main/java/itemtransformhelper/HUDtextRenderer.java
@@ -1,5 +1,9 @@
 package itemtransformhelper;
 
+import java.util.ArrayList;
+
+import javax.vecmath.Vector3f;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.GlStateManager;
@@ -10,15 +14,13 @@ import net.minecraft.client.renderer.block.model.ItemTransformVec3f;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
-import javax.vecmath.Vector3f;
-import java.util.ArrayList;
-
 /**
  * User: The Grey Ghost
  * Date: 20/01/2015
  * Class to draw the menu on the screen
  *
  */
+@SuppressWarnings("deprecation")
 public class HUDtextRenderer
 {
   /**

--- a/src/main/java/itemtransformhelper/ItemCamera.java
+++ b/src/main/java/itemtransformhelper/ItemCamera.java
@@ -1,12 +1,12 @@
 package itemtransformhelper;
 
+import java.util.List;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-
-import java.util.List;
 
 /**
  * User: The Grey Ghost
@@ -24,7 +24,7 @@ public class ItemCamera extends Item
 
   // adds 'tooltip' text
   @SideOnly(Side.CLIENT)
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({ "unchecked", "rawtypes" })
   @Override
   public void addInformation(ItemStack stack, EntityPlayer playerIn, List tooltip, boolean advanced) {
     tooltip.add("1) Place the camera in your hotbar");

--- a/src/main/java/itemtransformhelper/ItemModelFlexibleCamera.java
+++ b/src/main/java/itemtransformhelper/ItemModelFlexibleCamera.java
@@ -5,8 +5,13 @@ import java.util.List;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.renderer.vertex.VertexFormat;
 import net.minecraft.client.resources.model.IBakedModel;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
+import net.minecraftforge.client.model.Attributes;
+import net.minecraftforge.client.model.IFlexibleBakedModel;
+import net.minecraftforge.client.model.ISmartItemModel;
 
 /**
  * User: The Grey Ghost
@@ -21,12 +26,13 @@ import net.minecraft.util.EnumFacing;
  * Models which don't match itemModelToOverride will use their original transform
  */
 @SuppressWarnings({ "deprecation", "unchecked" })
-public class ItemModelFlexibleCamera implements IBakedModel
+public class ItemModelFlexibleCamera implements IFlexibleBakedModel, ISmartItemModel
 {
   public ItemModelFlexibleCamera(IBakedModel i_modelToWrap, UpdateLink linkToCurrentInformation)
   {
     updateLink = linkToCurrentInformation;
     iBakedModel = i_modelToWrap;
+    wrappedModel = i_modelToWrap;
   }
 
   @Override
@@ -64,18 +70,35 @@ public class ItemModelFlexibleCamera implements IBakedModel
     return (updateLink.itemModelToOverride == this) ? updateLink.forcedTransform : iBakedModel.getItemCameraTransforms();
   }
 
+  @Override
+  public IBakedModel handleItemState(ItemStack stack) {
+      if (wrappedModel instanceof ISmartItemModel) {
+          iBakedModel = ((ISmartItemModel)wrappedModel).handleItemState(stack);
+      }
+      return this;
+  }
+
+  @Override
+  public VertexFormat getFormat() {
+      if (iBakedModel instanceof IFlexibleBakedModel)
+      {
+          return ((IFlexibleBakedModel)iBakedModel).getFormat();
+      }
+      return Attributes.DEFAULT_BAKED_FORMAT;
+  }
+
   private final UpdateLink updateLink;
 
   public IBakedModel getIBakedModel() {
     return iBakedModel;
   }
 
-  private final IBakedModel iBakedModel;
+  private IBakedModel iBakedModel;
+  private IBakedModel wrappedModel;
 
   public static class UpdateLink
   {
     public IBakedModel itemModelToOverride;
     public ItemCameraTransforms forcedTransform;
   }
-
 }

--- a/src/main/java/itemtransformhelper/ItemModelFlexibleCamera.java
+++ b/src/main/java/itemtransformhelper/ItemModelFlexibleCamera.java
@@ -1,11 +1,12 @@
 package itemtransformhelper;
 
+import java.util.List;
+
+import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.model.IBakedModel;
 import net.minecraft.util.EnumFacing;
-
-import java.util.List;
 
 /**
  * User: The Grey Ghost
@@ -19,6 +20,7 @@ import java.util.List;
  *   b) forcedTransform is the transform to apply
  * Models which don't match itemModelToOverride will use their original transform
  */
+@SuppressWarnings({ "deprecation", "unchecked" })
 public class ItemModelFlexibleCamera implements IBakedModel
 {
   public ItemModelFlexibleCamera(IBakedModel i_modelToWrap, UpdateLink linkToCurrentInformation)
@@ -28,12 +30,12 @@ public class ItemModelFlexibleCamera implements IBakedModel
   }
 
   @Override
-  public List getFaceQuads(EnumFacing enumFacing) {
+  public List<BakedQuad> getFaceQuads(EnumFacing enumFacing) {
     return iBakedModel.getFaceQuads(enumFacing);
   }
 
   @Override
-  public List getGeneralQuads() {
+  public List<BakedQuad> getGeneralQuads() {
     return iBakedModel.getGeneralQuads();
   }
 

--- a/src/main/java/itemtransformhelper/MenuItemCameraTransforms.java
+++ b/src/main/java/itemtransformhelper/MenuItemCameraTransforms.java
@@ -10,6 +10,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
+
 import org.lwjgl.input.Keyboard;
 
 /**
@@ -18,6 +19,7 @@ import org.lwjgl.input.Keyboard;
  * The class registers its components on the Forge and FML event buses.
  * Created by TheGreyGhost on 22/01/15.
  */
+@SuppressWarnings("deprecation")
 public class MenuItemCameraTransforms
 {
   public MenuItemCameraTransforms()
@@ -58,6 +60,7 @@ public class MenuItemCameraTransforms
           alterField(whichKey == MenuKeyHandler.ArrowKeys.RIGHT);
           break;
         }
+        case NONE:
       }
     }
   }

--- a/src/main/java/itemtransformhelper/MenuItemCameraTransforms.java
+++ b/src/main/java/itemtransformhelper/MenuItemCameraTransforms.java
@@ -1,5 +1,7 @@
 package itemtransformhelper;
 
+import java.util.Locale;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
 import net.minecraft.client.renderer.block.model.ItemTransformVec3f;
@@ -161,24 +163,24 @@ public class MenuItemCameraTransforms
   }
 
   private static void printTransform(StringBuilder output, String transformView, ItemTransformVec3f itemTransformVec3f) {
-    output.append("  \"" + transformView + "\":{\n");
-    output.append("    \"rotation\": [");
-    output.append(String.format("%.0f, ", itemTransformVec3f.rotation.getX()));
-    output.append(String.format("%.0f, ", itemTransformVec3f.rotation.getY()));
-    output.append(String.format("%.0f],", itemTransformVec3f.rotation.getZ()));
+    output.append("    \"" + transformView + "\": {\n");
+    output.append("        \"rotation\": [ ");
+    output.append(String.format(Locale.US, "%.0f, ", itemTransformVec3f.rotation.getX()));
+    output.append(String.format(Locale.US, "%.0f, ", itemTransformVec3f.rotation.getY()));
+    output.append(String.format(Locale.US, "%.0f ],", itemTransformVec3f.rotation.getZ()));
     output.append("\n");
 
     final double TRANSLATE_MULTIPLIER = 1/ 0.0625;   // see ItemTransformVec3f::deserialize0()
-    output.append("    \"translation\": [");
-    output.append(String.format("%.2f, ", itemTransformVec3f.translation.getX() * TRANSLATE_MULTIPLIER));
-    output.append(String.format("%.2f, ", itemTransformVec3f.translation.getY() * TRANSLATE_MULTIPLIER));
-    output.append(String.format("%.2f],", itemTransformVec3f.translation.getZ() * TRANSLATE_MULTIPLIER));
+    output.append("        \"translation\": [ ");
+    output.append(String.format(Locale.US, "%.2f, ", itemTransformVec3f.translation.getX() * TRANSLATE_MULTIPLIER));
+    output.append(String.format(Locale.US, "%.2f, ", itemTransformVec3f.translation.getY() * TRANSLATE_MULTIPLIER));
+    output.append(String.format(Locale.US, "%.2f ],", itemTransformVec3f.translation.getZ() * TRANSLATE_MULTIPLIER));
     output.append("\n");
-    output.append("    \"scale\": [");
-    output.append(String.format("%.2f, ", itemTransformVec3f.scale.getX()));
-    output.append(String.format("%.2f, ", itemTransformVec3f.scale.getY()));
-    output.append(String.format("%.2f]", itemTransformVec3f.scale.getZ()));
-    output.append("\n  }");
+    output.append("        \"scale\": [ ");
+    output.append(String.format(Locale.US, "%.2f, ", itemTransformVec3f.scale.getX()));
+    output.append(String.format(Locale.US, "%.2f, ", itemTransformVec3f.scale.getY()));
+    output.append(String.format(Locale.US, "%.2f ]", itemTransformVec3f.scale.getZ()));
+    output.append("\n    }");
   }
 
   private static void copyTransforms(ItemTransformVec3f from, ItemTransformVec3f to)

--- a/src/main/java/itemtransformhelper/ModelBakeEventHandler.java
+++ b/src/main/java/itemtransformhelper/ModelBakeEventHandler.java
@@ -1,6 +1,5 @@
 package itemtransformhelper;
 
-import itemtransformhelper.ItemModelFlexibleCamera;
 import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
 import net.minecraft.client.renderer.block.model.ItemTransformVec3f;
 import net.minecraft.client.resources.model.IBakedModel;
@@ -17,6 +16,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
  * Each wrapped model gets a reference to ModelBakeEventHandler::itemOverrideLink.
  * Later, we can alter the members of itemOverrideLink to change the ItemCameraTransforms for a desired Item
  */
+@SuppressWarnings("deprecation")
 public class ModelBakeEventHandler
 {
   public ModelBakeEventHandler()


### PR DESCRIPTION
Changed the ItemModelFlexibleCamera to implement IFlexibleBakedModel instead of IBakedModel. Also made it implement ISmartItemModel.
In case of ISmartItemModel type models, the actual model is retrieved from the ISmartItemModel.handleItemState() and stored in the iBakedModel field. There is a new field wrappedModel which in this case stores the original wrapped model (which is the ISmartItemModel model).

(This at least worked for my items in Ender Utilities, which all use a generic ISmartItemModel model wrapper, which then retrieves the actual models from the item class, which are generated in code from the base models. This allows me to use a single generic json model for most items, and then just have separate json base models for items that require specific rotations, like tools.)
